### PR TITLE
Make Timeout Feature a Configurable Setting

### DIFF
--- a/pinball0.cxx
+++ b/pinball0.cxx
@@ -286,12 +286,22 @@ static void pinball_draw_callback(Canvas* const canvas, void* ctx) {
         if(pb->settings.selected_setting == 3) {
             canvas_draw_triangle(canvas, 2, y + 3, 8, 5, CanvasDirectionLeftToRight);
         }
+        y += 12;
+
+        canvas_draw_str_aligned(canvas, 10, y, AlignLeft, AlignTop, "Timeout");
+        canvas_draw_circle(canvas, x, y + 3, 4);
+        if(pb->settings.timeout_enabled) {
+            canvas_draw_disc(canvas, x, y + 3, 2);
+        }
+        if(pb->settings.selected_setting == 4) {
+            canvas_draw_triangle(canvas, 2, y + 3, 8, 5, CanvasDirectionLeftToRight);
+        }
 
         // About information
-        canvas_draw_str_aligned(canvas, 2, 88, AlignLeft, AlignTop, "Pinball0 " VERSION);
-        canvas_draw_str_aligned(canvas, 2, 98, AlignLeft, AlignTop, "github.com/");
-        canvas_draw_str_aligned(canvas, 2, 108, AlignLeft, AlignTop, "  rdefeo/");
-        canvas_draw_str_aligned(canvas, 2, 118, AlignLeft, AlignTop, "    pinball0");
+        canvas_draw_str_aligned(canvas, 2, 98, AlignLeft, AlignTop, "Pinball0 " VERSION);
+        canvas_draw_str_aligned(canvas, 2, 108, AlignLeft, AlignTop, "github.com/");
+        canvas_draw_str_aligned(canvas, 2, 118, AlignLeft, AlignTop, "  rdefeo/");
+        canvas_draw_str_aligned(canvas, 2, 128, AlignLeft, AlignTop, "    pinball0");
 
         pb->table->draw(canvas);
     } break;
@@ -587,6 +597,9 @@ extern "C" int32_t pinball0_app(void* p) {
                         case 3:
                             app.settings.debug_mode = !app.settings.debug_mode;
                             break;
+                        case 4:
+                            app.settings.timeout_enabled = !app.settings.timeout_enabled;
+                            break;
                         default:
                             break;
                         }
@@ -633,7 +646,7 @@ extern "C" int32_t pinball0_app(void* p) {
 
         // game timing + idle check
         uint32_t current_tick = furi_get_tick();
-        if(current_tick - app.idle_start >= IDLE_TIMEOUT) {
+        if(app.settings.timeout_enabled && current_tick - app.idle_start >= IDLE_TIMEOUT) {
             FURI_LOG_W(TAG, "Idle timeout! Exiting Pinball0...");
             app.processing = false;
             break;

--- a/settings.cxx
+++ b/settings.cxx
@@ -19,8 +19,9 @@ void pinball_load_settings(PinballApp& pb) {
     settings.led_enabled = true;
     settings.vibrate_enabled = true;
     settings.debug_mode = false;
+    settings.timeout_enabled = true;
     settings.selected_setting = 0;
-    settings.max_settings = 4;
+    settings.max_settings = 5;
 
     do {
         if(!flipper_format_file_open_existing(fff_settings, PINBALL_SETTINGS_PATH)) {
@@ -48,6 +49,9 @@ void pinball_load_settings(PinballApp& pb) {
         }
         if(flipper_format_read_uint32(fff_settings, "Debug", &tmp_data32, 1)) {
             settings.debug_mode = (tmp_data32 == 0) ? false : true;
+        }
+        if (flipper_format_read_uint32(fff_settings, "Timeout", &tmp_data32, 1)) {
+            settings.timeout_enabled = (tmp_data32 == 0) ? false : true;
         }
 
     } while(false);
@@ -91,6 +95,11 @@ void pinball_save_settings(PinballApp& pb) {
         tmp_data32 = settings.debug_mode ? 1 : 0;
         if(!flipper_format_write_uint32(fff_settings, "Debug", &tmp_data32, 1)) {
             FURI_LOG_E(TAG, "SETTINGS: Failed to write 'Debug'");
+            break;
+        }
+        tmp_data32 = settings.timeout_enabled ? 1 : 0;
+        if(!flipper_format_write_uint32(fff_settings, "Timeout", &tmp_data32, 1)) {
+            FURI_LOG_E(TAG, "SETTINGS: Failed to write 'Timeout'");
             break;
         }
     } while(false);

--- a/settings.h
+++ b/settings.h
@@ -5,6 +5,7 @@ typedef struct {
     bool vibrate_enabled;
     bool led_enabled;
     bool debug_mode;
+    bool timeout_enabled;
 
     int selected_setting;
     int max_settings;


### PR DESCRIPTION
Makes exit timeout a configurable setting (on by default) instead of always exiting once two minutes of inactivity is reached.
This can be useful especially when the game is in a state where the ball is bouncing between objects on the board for a prolonged period of time but the user does not wish to exit.